### PR TITLE
Test for fixing IDs and eliminating private Chat userName

### DIFF
--- a/Telegram/SourceFiles/cloudveil/DialogHelper.cpp
+++ b/Telegram/SourceFiles/cloudveil/DialogHelper.cpp
@@ -11,7 +11,8 @@ DialogHelper::CheckDialogResult DialogHelper::checkAndShowDialogForbidden(PeerDa
 		controller->show(Ui::MakeConfirmBox({
 					.text = tr::lng_dialog_forbidden(),
 					.confirmed = [=](Fn<void()>&& close) {
-						const auto dialogId = DeserializePeerId(peerData->id.value).value;
+						//const auto dialogId = DeserializePeerId(peerData->id.value).value; // this was causing 404s on unblock requests
+						const auto dialogId = peerData->id.value;
 						QString url = QString("https://messenger.cloudveil.org/unblock/%1/%2")
 							.arg(QString::number(userData->id.value), QString::number(dialogId));
 

--- a/Telegram/SourceFiles/cloudveil/GlobalSecuritySettings.cpp
+++ b/Telegram/SourceFiles/cloudveil/GlobalSecuritySettings.cpp
@@ -183,19 +183,22 @@ void GlobalSecuritySettings::checkStickerSetByDocumentAsync(DocumentData* sticke
 }
 
 void GlobalSecuritySettings::addDialogToRequest(SettingsRequest &request, PeerData *peer) {
-	qint64 dialogId = DeserializePeerId(peer->id.value).value;
-	
+	//qint64 dialogId = DeserializePeerId(peer->id.value).value;
+	qint64 dialogId = peer->id.value; //for CV Manage, we want the bare value
+
 	SettingsRequest::Row row;
 	row.id = dialogId;
 
-	row.userName = peer->userName();
+	row.userName = peer->userName(); // should we be setting this one? 
+	//If it's Chat, it can't have userName; if it's Channel or User it may. 
+	// If there's a chance this results in 'N/A' or similar, we don't want it.
 	row.isMegagroup = false;
 	row.isPublic = false;
 
 	if (peer->isChat()) {
 		row.title = peer->asChat()->name();
-		row.userName = row.title;
-		row.isPublic = peer->asChat()->flags() & 0x00000040;
+		//row.userName = row.title; //this should not be set, was it set to solve a different problem?
+		row.isPublic = peer->asChat()->flags() & 0x00000040; //2025-01-18 currently, Chat can only be Private, not Public
 		request.groups.append(row);
 	}
 	else if (peer->isChannel()) {

--- a/Telegram/SourceFiles/cloudveil/response/SettingsResponse.cpp
+++ b/Telegram/SourceFiles/cloudveil/response/SettingsResponse.cpp
@@ -234,7 +234,8 @@ bool SettingsResponse::isDialogAllowed(PeerData *peer) {
 		return true;
 	}
 
-	const auto dialogId = DeserializePeerId(peer->id.value).value;
+	//const auto dialogId = DeserializePeerId(peer->id.value).value;
+	const auto dialogId = peer->id.value;
 	if (peer->isChat() || peer->isMegagroup()) {
 		return groups.contains(dialogId) && groups[dialogId];
 	}
@@ -275,7 +276,8 @@ bool SettingsResponse::isDialogSecured(PeerData *peer) {
 	if (peer->isUser() && peer->asUser()->isSelf()) {
 		return true;
 	}
-	const auto dialogId = DeserializePeerId(peer->id.value).value;
+	//const auto dialogId = DeserializePeerId(peer->id.value).value;
+	const auto dialogId = peer->id.value;
 	return bots.contains(dialogId) ||
 		channels.contains(dialogId) ||
 		groups.contains(dialogId) ||


### PR DESCRIPTION
This is untested. Primary focus was to restore ID numbers to not use DeserializePeerId, which was affecting some IDs (beyond 2^31) reported to manage server. Also remove userName on private chats, which was affecting change requests.

I realize this is possibly waiting for major rebase, so no problem if this doesn't get actioned before rebase. But @patriciy if you had a test build with this, I could verify whether it acts correctly for what manage expects.

Also if it is possible to do a test build for 32 bit Windows, there is one user who would appreciate it. That is not high priority though. I think if we did one 32 build, we wouldn't have to maintain it in the future.